### PR TITLE
Add fingerprints support

### DIFF
--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -52,7 +52,7 @@ module Jammit
 
   class << self
     attr_reader   :configuration, :template_function, :template_namespace,
-                  :embed_assets, :package_assets, :compress_assets, :gzip_assets,
+                  :embed_assets, :tag_assets, :package_assets, :compress_assets, :gzip_assets,
                   :package_path, :mhtml_enabled, :include_jst_script, :config_path,
                   :javascript_compressor, :compressor_options, :css_compressor,
                   :css_compressor_options, :template_extension,
@@ -93,6 +93,7 @@ module Jammit
     @configuration          = symbolize_keys(conf)
     @package_path           = conf[:package_path] || DEFAULT_PACKAGE_PATH
     @embed_assets           = conf[:embed_assets] || conf[:embed_images]
+    @tag_assets             = conf[:tag_assets].nil? || conf[:tag_assets] # defaults to true
     @compress_assets        = !(conf[:compress_assets] == false)
     @rewrite_relative_paths = !(conf[:rewrite_relative_paths] == false)
     @gzip_assets            = !(conf[:gzip_assets] == false)

--- a/lib/jammit.rb
+++ b/lib/jammit.rb
@@ -77,6 +77,14 @@ module Jammit
     raise MissingConfiguration, "could not find the \"#{config_path}\" configuration file" unless exists
     conf = YAML.load(ERB.new(File.read(config_path)).result)
 
+    conf["root_paths"] ||= []
+    conf["root_paths"] << ASSET_ROOT
+    (conf["includes"] || []).map do |include_path|
+      new_config = YAML.load(ERB.new(File.read(include_path)).result)
+      conf = new_config.deep_merge(conf)
+      conf["root_paths"] << new_config["root_path"]
+    end
+
     # Optionally overwrite configuration based on the environment.
     rails_env = (defined?(Rails) ? ::Rails.env : ENV['RAILS_ENV'] || "development")
     conf.merge! conf.delete rails_env if conf.has_key? rails_env

--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -222,7 +222,14 @@ module Jammit
     def rails_asset_id(path)
       asset_id = ENV["RAILS_ASSET_ID"]
       return asset_id if asset_id
-      File.exists?(path) ? File.mtime(path).to_i.to_s : ''
+      case Jammit.tag_assets
+      when "md5"
+        File.exists?(path) ? Digest::MD5.file(path).hexdigest : ''
+      when false
+        ''
+      else # mtime is default
+        File.exists?(path) ? File.mtime(path).to_i.to_s : ''
+      end
     end
 
     # An asset is valid for embedding if it exists, is less than 32K, and is

--- a/lib/jammit/helper.rb
+++ b/lib/jammit/helper.rb
@@ -39,8 +39,21 @@ module Jammit
       raise DeprecationError, "Jammit 0.5+ no longer supports separate packages for templates.\nYou can include your JST alongside your JS, and use include_javascripts."
     end
 
+    def javascripts_packaged(*packages)
+      assets_packaged(packages, :js)
+    end
+
+    def stylesheets_packaged(*packages)
+      assets_packaged(packages, :css)
+    end
 
     private
+
+    def assets_packaged(packages, format)
+      packages.map do |package|
+        should_package? ? Jammit.asset_url(package, format) : Jammit.packager.individual_urls(package.to_sym, format)
+      end.flatten
+    end
 
     def should_package?
       Jammit.package_assets && !(Jammit.allow_debugging && params[:debug_assets])

--- a/lib/jammit/packager.rb
+++ b/lib/jammit/packager.rb
@@ -65,7 +65,9 @@ module Jammit
       raise OutputNotWritable, "Jammit doesn't have permission to write to \"#{output_dir}\"" unless File.writable?(output_dir)
       mtime ||= latest_mtime package_for(package, extension.to_sym)[:paths]
       files = []
-      fingerprint = Digest::MD5.hexdigest(contents)
+      # We encode the fingerprint with UTF-8 since otherwise its yaml representation is
+      # an unreadable binary string
+      fingerprint = Digest::MD5.hexdigest(contents).encode("UTF-8")
       name = Jammit.fingerprints_enabled? ? "#{package}-#{fingerprint}" : package
       files << file_name = File.join(output_dir, Jammit.filename(name, extension, suffix))
       File.open(file_name, 'wb+') {|f| f.write(contents) }
@@ -136,7 +138,7 @@ module Jammit
     #    something:
     #      - "/foo/bar/public/javascripts/shomething.js"
     #
-    # In Rails, the difference between a path and an asset URL is "public".    
+    # In Rails, the difference between a path and an asset URL is "public".
     def path_to_url
       @path_to_url ||= /\A(#{Array.wrap(Jammit.configuration[:root_paths]).map { |path| Regexp.escape(path) }.join("|")})(.*public)?/
     end

--- a/lib/jammit/packager.rb
+++ b/lib/jammit/packager.rb
@@ -108,9 +108,25 @@ module Jammit
       paths
     end
 
+    # In case we have assets in gems, we may want to pack them from there.
+    # This adds support for additional root paths through :root_path definition in included assets YAML files
+    #
+    # File assets1.yml:
+    #
+    # includes:
+    #    - "/foo/bar/config/assets2.yml"
+    #
+    # File assets2.yml
+    #
+    # root_path: /foo/bar
+    #
+    # javascripts:
+    #    something:
+    #      - "/foo/bar/public/javascripts/shomething.js"
+    #
     # In Rails, the difference between a path and an asset URL is "public".    
     def path_to_url
-      @path_to_url ||= /\A#{Regexp.escape(ASSET_ROOT)}(\/?#{Regexp.escape(Jammit.public_root.sub(ASSET_ROOT, ''))})?/
+      @path_to_url ||= /\A(#{Array.wrap(Jammit.configuration[:root_paths]).map { |path| Regexp.escape(path) }.join("|")})(.*public)?/
     end
 
     # Get the latest mtime of a list of files (plus the config path).

--- a/lib/jammit/packager.rb
+++ b/lib/jammit/packager.rb
@@ -33,10 +33,14 @@ module Jammit
     # changed since their last package build.
     def precache_all(output_dir=nil, base_url=nil)
       output_dir ||= File.join(Jammit.public_root, Jammit.package_path)
-      cacheable(:js, output_dir).each  {|p| cache(p, 'js',  pack_javascripts(p), output_dir) }
+      fingerprints_by_types = {"js" => {}, "css" => {}}
+      cacheable(:js, output_dir).each do |p|
+        fingerprints_by_types["js"][p.to_s] = cache(p, 'js',  pack_javascripts(p), output_dir)
+      end
       cacheable(:css, output_dir).each do |p|
-        cache(p, 'css', pack_stylesheets(p), output_dir)
+        fingerprints_by_types["css"][p.to_s] = cache(p, 'css', pack_stylesheets(p), output_dir)
         if Jammit.embed_assets
+          # Don't support fingerprinting for embedded assets for now
           cache(p, 'css', pack_stylesheets(p, :datauri), output_dir, :datauri)
           if Jammit.mhtml_enabled
             raise MissingConfiguration, "A --base-url option is required in order to generate MHTML." unless base_url
@@ -44,6 +48,11 @@ module Jammit
             asset_url = "#{base_url}#{Jammit.asset_url(p, :css, :mhtml, mtime)}"
             cache(p, 'css', pack_stylesheets(p, :mhtml, asset_url), output_dir, :mhtml, mtime)
           end
+        end
+      end
+      if Jammit.fingerprints_enabled?
+        File.open(Jammit.config_path + ".lock", 'w') do |file|
+          file.puts(fingerprints_by_types.to_yaml)
         end
       end
     end
@@ -56,13 +65,16 @@ module Jammit
       raise OutputNotWritable, "Jammit doesn't have permission to write to \"#{output_dir}\"" unless File.writable?(output_dir)
       mtime ||= latest_mtime package_for(package, extension.to_sym)[:paths]
       files = []
-      files << file_name = File.join(output_dir, Jammit.filename(package, extension, suffix))
+      fingerprint = Digest::MD5.hexdigest(contents)
+      name = Jammit.fingerprints_enabled? ? "#{package}-#{fingerprint}" : package
+      files << file_name = File.join(output_dir, Jammit.filename(name, extension, suffix))
       File.open(file_name, 'wb+') {|f| f.write(contents) }
       if Jammit.gzip_assets
         files << zip_name = "#{file_name}.gz"
         Zlib::GzipWriter.open(zip_name, Zlib::BEST_COMPRESSION) {|f| f.write(contents) }
       end
       File.utime(mtime, mtime, *files)
+      fingerprint
     end
 
     # Get the list of individual assets for a package.


### PR DESCRIPTION
@ajlai PTAL

You can turn it on by seeting 'fingerprints_enabled: true' in your
assets.yml.

If it is enabled, when you package your assets, the fingerprint suffix
will be added to them, and assets.yaml.lock will be created. Then, when
the pages are displayed, the values from assets.yaml.lock will be
retrieved to get the suffix for the asset.
